### PR TITLE
I72 context

### DIFF
--- a/schema/ContextCase.json
+++ b/schema/ContextCase.json
@@ -1,0 +1,41 @@
+{
+    "receiver": {
+      "aetitle": "TestQCTool",
+      "port": 11112          
+    },
+    "destination": {
+      "aetitle": "TestDestination",
+      "hostname": "localhost",
+      "port": 11113
+    },
+    "quarentine": {
+      "aetitle": "TestQuarentine",
+      "hostname": "localhost",
+      "port": 11114
+    },
+    "context":{
+      "1.2.840.10008.5.1.4.1.1.3.1":[
+        "1.2.840.10008.1.2.4.50"
+    ]
+    },
+    "metadata": {
+        "(0010,0010)": {
+          "tagName": "PatientName",
+          "vr": "CS",
+          "description": "check if patient is called 'bob' and change, if so.",
+          "operations": {
+            "EQUAL": {
+                "otherTagString": "",
+                "value": "John Doe",
+                "IF_TRUE": {
+                    "OVERWRITE": {
+                        "tag": "",
+                        "replaceString": "Robert"
+                    }
+                }
+            }
+          }
+        }
+        
+    }
+}

--- a/src/Conductor.cpp
+++ b/src/Conductor.cpp
@@ -20,39 +20,42 @@ using json = nlohmann::ordered_json;
 Conductor::Conductor(std::istream &json_config) {
   auto config = json::parse(json_config);
   setup_parser(config["metadata"]);
-  setup_receiver(config["receiver"]["aetitle"], config["receiver"]["port"]);
+  setup_receiver(config["receiver"]["aetitle"], config["receiver"]["port"],config["context"]);
   setup_destination(
       "QCtool Destination Sender", config["destination"]["aetitle"],
-      config["destination"]["hostname"], config["destination"]["port"]);
+      config["destination"]["hostname"], config["destination"]["port"], config["context"]);
   setup_quarentine(
       "QCtool Quarentine Sender", config["quarentine"]["aetitle"],
-      config["quarentine"]["hostname"], config["quarentine"]["port"]);
+      config["quarentine"]["hostname"], config["quarentine"]["port"], config["context"]);
 }
  
 void Conductor::setup_parser(const json &config) { m_parser.setConfig(config); }
 
-void Conductor::setup_receiver(const std::string &aetitle, const int port) {
+void Conductor::setup_receiver(const std::string &aetitle, const int port,const json &context) {
   m_receiver.setaetitle(aetitle);
   m_receiver.setportnumber(port);
+  m_receiver.set_additional_context(context);
   m_todo = OFshared_ptr<ThreadSafeQueue<DcmDataset>>(new ThreadSafeQueue<DcmDataset>);
   m_receiver.setpointer(m_todo);
   m_receiver.start();
 }
 
 void Conductor::setup_destination(const std::string &aetitle, const std::string &peer_aetitle,
-                                  const std::string &hostname, const int port) {
+                                  const std::string &hostname, const int port,const json &context) {
   m_destination.set_aetitle(aetitle);
   m_destination.set_peer_aetitle(peer_aetitle);
   m_destination.set_peer_hostname(hostname);
   m_destination.set_peer_port(port);
+  m_destination.set_additional_context(context);
 }
 
 void Conductor::setup_quarentine(const std::string &aetitle,const std::string &peer_aetitle,
-                                 const std::string &hostname, const int port) {
+                                 const std::string &hostname, const int port, const json &context) {
   m_quarentine.set_aetitle(aetitle);
   m_quarentine.set_peer_aetitle(peer_aetitle);
   m_quarentine.set_peer_hostname(hostname);
   m_quarentine.set_peer_port(port);
+  m_quarentine.set_additional_context(context);
 }
 
 //void Conductor setup_image_editor

--- a/src/Conductor.hpp
+++ b/src/Conductor.hpp
@@ -26,14 +26,14 @@ public:
   
 private:
   void setup_parser(const json &config);
-  void setup_receiver(const std::string &aetitle, int port);
+  void setup_receiver(const std::string &aetitle, int port,const json &context);
 
   void setup_destination(const std::string &aetitle,
                          const std::string &peer_aetitle,
-                         const std::string &hostname, const int port);
+                         const std::string &hostname, const int port, const json &context);
   void setup_quarentine(const std::string &aetitle,
                         const std::string &peer_aetitle,
-                        const std::string &hostname, const int port);
+                        const std::string &hostname, const int port, const json &context);
   void initialise(const std::string &json_config);
   void process_dataset(DcmDataset dataset);
 };

--- a/src/communication/Receiver.cpp
+++ b/src/communication/Receiver.cpp
@@ -9,6 +9,9 @@
 #include "dcmtk/oflog/oflog.h"
 #include "logging.hpp"
 
+#include "../libs/nlohmann_json/single_include/nlohmann/json.hpp"
+using json = nlohmann::ordered_json;
+
 // ----------------------------------------------------------------------------
 
 ReceiverThread::ReceiverThread() : DcmThreadSCP() {}
@@ -159,7 +162,7 @@ Receiver::Receiver(Uint16 port, std::string aetitle) {
    getConfig().addPresentationContext(UID_SecondaryCaptureImageStorage,xfers);
    getConfig().addPresentationContext(UID_VerificationSOPClass, xfers);
    getConfig().addPresentationContext(UID_DigitalXRayImageStorageForPresentation, ts);
-   getConfig().addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
+   //getConfig().addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
 }
 
 // ----------------------------------------------------------------------------
@@ -185,3 +188,20 @@ void Receiver::setaetitle(std::string ae_title) {
 // ----------------------------------------------------------------------------
 
 void Receiver::setportnumber(Uint16 port) { getConfig().setPort(port); }
+
+void Receiver::set_additional_context(const json &context){
+    OFList<OFString> xfers;
+    for (const auto &param : context.items()) {
+        xfers.clear();
+        OFString UID = OFString(param.key().c_str());
+        const auto &ts_value = param.value(); 
+        
+        for (const auto &xfer : ts_value.get<std::vector<std::string>>())
+        {
+          xfers.push_back(xfer.c_str());
+        }
+        
+        getConfig().addPresentationContext(UID, xfers);
+    }
+    
+}

--- a/src/communication/Receiver.cpp
+++ b/src/communication/Receiver.cpp
@@ -162,7 +162,7 @@ Receiver::Receiver(Uint16 port, std::string aetitle) {
    getConfig().addPresentationContext(UID_SecondaryCaptureImageStorage,xfers);
    getConfig().addPresentationContext(UID_VerificationSOPClass, xfers);
    getConfig().addPresentationContext(UID_DigitalXRayImageStorageForPresentation, ts);
-   //getConfig().addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
+   getConfig().addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/communication/Receiver.hpp
+++ b/src/communication/Receiver.hpp
@@ -5,6 +5,9 @@
 #include <dcmtk/dcmnet/scpthrd.h>
 #include "poolbase.h"
 #include "ThreadSafeQueue.hpp"
+
+#include "../libs/nlohmann_json/single_include/nlohmann/json.hpp"
+using json = nlohmann::ordered_json;
 /**
  * A worker thread in a multithreaded Service Class Provider. 
  * Runs an association from an already accepted connection.
@@ -87,6 +90,11 @@ public:
      *  @param port Port to be used by the SCP. Default is "11112".
      */ 
     void setportnumber(Uint16 port);
+
+    /** Set the presentation context and transfer syntax. 
+     *  @param context The context to be specified.
+     */ 
+    void set_additional_context(const json &context);
 
     DcmDataset* getpooldataset();
 

--- a/src/communication/Sender.cpp
+++ b/src/communication/Sender.cpp
@@ -45,7 +45,7 @@ Sender::Sender(std::string aetitle, std::string peer_hostname, Uint16 peer_port,
    addPresentationContext(UID_SecondaryCaptureImageStorage,xfers);
    addPresentationContext(UID_VerificationSOPClass, xfers);
    addPresentationContext(UID_DigitalXRayImageStorageForPresentation, ts);
-   //addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
+   addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
    
 }
 

--- a/src/communication/Sender.cpp
+++ b/src/communication/Sender.cpp
@@ -45,7 +45,7 @@ Sender::Sender(std::string aetitle, std::string peer_hostname, Uint16 peer_port,
    addPresentationContext(UID_SecondaryCaptureImageStorage,xfers);
    addPresentationContext(UID_VerificationSOPClass, xfers);
    addPresentationContext(UID_DigitalXRayImageStorageForPresentation, ts);
-   addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
+   //addPresentationContext(UID_UltrasoundMultiframeImageStorage,ts2);
    
 }
 
@@ -60,6 +60,23 @@ void Sender::set_peer_hostname(const std::string& hostname) {
 }
 void Sender::set_peer_aetitle(const std::string& title) {
   setPeerAETitle(title.c_str());
+}
+
+void Sender::set_additional_context(const json &context){
+    OFList<OFString> xfers;
+    for (const auto &param : context.items()) {
+        xfers.clear();
+        OFString UID = OFString(param.key().c_str());
+        const auto &ts_value = param.value(); 
+        
+        for (const auto &xfer : ts_value.get<std::vector<std::string>>())
+        {
+          xfers.push_back(xfer.c_str());
+        }
+        
+        addPresentationContext(UID, xfers);
+    }
+    
 }
 
 

--- a/src/communication/Sender.hpp
+++ b/src/communication/Sender.hpp
@@ -5,6 +5,9 @@
 
 #include "dcmtk/dcmnet/dstorscu.h" /* Covers most common dcmdata classes */
 
+#include "../libs/nlohmann_json/single_include/nlohmann/json.hpp"
+using json = nlohmann::ordered_json;
+
 class Sender : public DcmStorageSCU {
 
 public:
@@ -21,6 +24,7 @@ public:
   void set_peer_port( int port);
   void set_peer_hostname(const std::string &hostname);
   void set_peer_aetitle(const std::string &title);
+  void set_additional_context(const json &context);
 
   OFCondition send(DcmDataset &dataset);
   OFCondition send_file(const std::string &filename);


### PR DESCRIPTION
I‘ve added one new feature to the pipeline. Instead of specifying the presentation contexts and transfer syntaxes in the source code, we now enable the user to add their own contexts in the configuration file (see schema/ContextCase.json as an example).