### PR TITLE
Delete improper unit tests

### DIFF
--- a/tests/SenderTests.cpp
+++ b/tests/SenderTests.cpp
@@ -23,20 +23,6 @@ static char rcsid[] = "$dcmtk: " OFFIS_CONSOLE_APPLICATION " v"
   OFFIS_DCMTK_VERSION " " OFFIS_DCMTK_RELEASEDATE " $";
   */
 
-TEST_CASE("Test C-ECHO Request with SCU, and add logging", "[STN]") {
-  set_root_logging("../TestSender_root.log", true);
-  set_logging("../TestSender.log", true);
-  std::string ae_title = "TEST-SCU";
-  std::string peer_hostname = "www.dicomserver.co.uk";
-  Uint16 peer_port = 11112;
-  std::string peer_aetitle = "MOVESCP";
-  Sender scu(ae_title, peer_hostname, peer_port, peer_aetitle);
-
-  auto result = scu.send_echo();
-
-
-  CHECK(result.good());
-}
 
 TEST_CASE("Test C-ECHO Request with SCU", "[ST]") {
   std::string ae_title = "TEST-SCU";


### PR DESCRIPTION
There was an improper unit-test in the SenderTests.cpp, which I deleted in the PR. The unit test used a remote server called www.dicomserver.co.uk, which might be shut down in the past few weeks.